### PR TITLE
Author path change

### DIFF
--- a/R/bibtex_core_data.R
+++ b/R/bibtex_core_data.R
@@ -30,7 +30,7 @@ bibtex_core_data = function(x) {
   # https://github.com/scopus-api/scopus/blob/master/scopus/abstract_retrieval.py#L598
   content = httr::content(x$get_statement, as = "text")
   content = jsonlite::fromJSON(content, flatten = TRUE)
-  authors = content$`abstracts-retrieval-response`$authors$author
+  authors = content$`abstracts-retrieval-response`$coredata$`dc:creator`$author
 
   self =  content$`abstracts-retrieval-response`$coredata
   if (is.null(self)) {


### PR DESCRIPTION
On running the [example](https://rdrr.io/github/muschellij2/rscopus/man/bibtex_core_data.html), (or on my own data) the result returns: "@article{}" instead of a formatted .bib

After some hours of digging, it looks like the structure of the data from the scopus API has changed (see proposed change to line 33).

The output appears correct after the edit to the function but please review to make sure there is no knock-on effect down the line!

Thanks very much for the rscopus package I hope this change helps!
Quinn